### PR TITLE
修复pageControl

### DIFF
--- a/CHGMenuSample/CHGGridView/CHGMenu/CHGMenu.m
+++ b/CHGMenuSample/CHGGridView/CHGMenu/CHGMenu.m
@@ -53,7 +53,7 @@
     _pageControl.currentPage = currPage;
     _pageControl.currentPageIndicatorTintColor = [UIColor redColor];;
     _pageControl.pageIndicatorTintColor = [UIColor lightGrayColor];
-    _pageControl.userInteractionEnabled = NO;
+//     _pageControl.userInteractionEnabled = NO;
     [_gridView reloadData];
 }
 
@@ -115,6 +115,7 @@
 -(void)setShowPageControl:(BOOL)showPageControl{
     _showPageControl = showPageControl;
     _pageControl.hidden = !showPageControl;
+    _pageControl.userInteractionEnabled = NO;   //此处关闭交互有效
     self.gridView.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
 }
 


### PR DESCRIPTION
原_pageControl是可以点击左右移动的，但是上面的button并没有同步移动。故，让_pageControl不能响应事件。
查看了下代码，发现-(void)reloadData中的_pageControl.userInteractionEnabled = NO方法无效，应写在-(void)setShowPageControl:(BOOL)showPageControl方法中。